### PR TITLE
Use ellipsize instead of custom code.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var ellipsize = require('ellipsize');
+
 exports.install = function (Vue, opts) {
 
   var filter = function(text, length, clamp){
@@ -7,7 +9,7 @@ exports.install = function (Vue, opts) {
     var node = document.createElement('div');
     node.innerHTML = text;
     var content = node.textContent;
-    return content.length > length ? content.slice(0, length) + clamp : content;
+    return ellipsize(content, length, { ellipse: clamp });
   };
 
   Vue.filter('truncate', filter);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "email": "brendanjneufeld@gmail.com",
     "url": "https://github.com/BrenanNeufeld"
   },
-  "dependencies": {},
+  "dependencies": {
+    "ellipsize": "0.0.2"
+  },
   "devDependencies": {},
   "scripts": {
     "test": "node test.js"


### PR DESCRIPTION
Since I take it the purpose of this filter is to truncate human-readable text, I believe it makes more sense to use the already-available ellipsize module (which accounts for many edge cases).
